### PR TITLE
[ calendar-EDIT ] 일별 공연 리스트의 map메서드의 중복된 key를 해결하라

### DIFF
--- a/app/cultureCalendar/Calendar.jsx
+++ b/app/cultureCalendar/Calendar.jsx
@@ -2,20 +2,22 @@
 import React, { useState, useEffect } from "react";
 import styles from "./cultureCalendar.module.css";
 import Link from "next/link";
+import { v4 as uuidv4 } from "uuid";
+
 // util함수 import
 import { API_SortFunc, serviceKey } from "../util/utils";
 import { useMonthNavigation } from "../util/hooks/useMonthNavigator";
-import { Modal } from "../util/Modal";
+import { Modal } from "./Modal";
 import ExpandedViewText from "./ExpandedText";
-
 
 export default function Calendar() {
   const todayDate = new Date();
   const [apiData, setApiData] = useState([]);
-  const [ isModalOpen, setIsModalOpen] = useState(false)
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [moreData, setMoreData] = useState(null);
   const { curDate, handlePrevMonth, handleNextMonth } =
     useMonthNavigation(todayDate);
-  
+
   // API호출
   const urlDate = `${curDate.year}-${String(curDate.month + 1).padStart(
     2,
@@ -37,10 +39,34 @@ export default function Calendar() {
 
   // calendar생성
   const numberDate = new Date(curDate.year, curDate.month + 1, 0).getDate();
-  // -- 유사배열객체 생성, lnegth길이만큼 배열생성 / 두번째 인수의 반환값으로 구성된 배열반환
+
+  // numberDate 길이의 배열생성
   const numbersArray = Array.from({ length: numberDate }, (_, index) =>
     (index + 1).toString().padStart(2, "0")
   );
+
+  //
+  const filterDataList = numbersArray.map((ele, idx) => {
+    // 해당 일의 공연 필터링 함수
+    const API_calendarDataFilter = apiData.filter((data, idx) => {
+      const currentDate = data.STRTDATE.split(" ")[0].split("-")[2];
+      return currentDate == ele;
+    });
+    // 중복되지 않는 key를 생성해놓은 배열
+    const uniqueIds = Array.from(
+      { length: API_calendarDataFilter.length },
+      () => uuidv4()
+    );
+    let cellStyle = {};
+
+    return {
+      date: ele,
+      cellStyle,
+      API_calendarDataFilter,
+      uniqueIds,
+    };
+  });
+
   const gridColumnStart = new Date(curDate.year, curDate.month, 1).getDay() + 1;
   const firstGridDateStyle = { gridColumnStart: gridColumnStart };
 
@@ -52,11 +78,13 @@ export default function Calendar() {
     return new Date(year, month, day).getDay() === 6;
   };
 
-  // List 모달창 
-  const handleAddList = () => {
-    
+  // 더보기 버튼 -> 모달 생성
+  const handleClickMoreData = (data) => {
+    // console.log(data);
+    setMoreData(data);
+    setIsModalOpen(true);
   };
-  
+
   return (
     <div className={styles.calendarBox}>
       <div className={styles.calendarMonth}>
@@ -76,8 +104,7 @@ export default function Calendar() {
         <p className={styles.day}>SAT</p>
       </div>
       <div className={styles.dates}>
-        {numbersArray?.map((ele) => {
-          let cellStyle = {};
+        {filterDataList?.map((ele, dateIdx) => {
           if (isSunday(curDate.year, curDate.month, ele)) {
             cellStyle.color = "red";
           }
@@ -85,37 +112,32 @@ export default function Calendar() {
             cellStyle.color = "blue";
           }
 
-          // 해당 일의 공연 필터링 함수
-          const API_calendarDataFilter = apiData.filter((data) => {
-            const currentDate = data.STRTDATE.split(" ")[0].split("-")[2];
-            return currentDate == ele;
-          });
-
-          return ele == "01" ? (
+          return ele.date == '01' ? (
             <div
-              key={ele}
+              key={dateIdx + 1}
               className={styles.dateBox}
               style={{ ...firstGridDateStyle }}
-            >
-              <p className={styles.date} style={cellStyle}>
-                {ele}
+            > 
+              <p className={styles.date} style={ele.cellStyle}>
+                {ele.date}
               </p>
               <div className={styles.dateCultureList}>
                 <ul>
-                  {API_calendarDataFilter.map((data, idx) => {
+                  {ele.API_calendarDataFilter.map((data, idx) => {
                     if (idx < 5) {
                       return (
-                        <>
-                          <li key={idx} className={styles.calendarDataList}>
+                        <React.Fragment key={ele.uniqueIds[idx]}>
+                          <li className={styles.calendarDataList}>
                             <Link href={data.ORG_LINK} target="_blank">
                               {data.TITLE}
                             </Link>
+                            <button>자세히보기</button>
                           </li>
-                        </>
+                        </React.Fragment>
                       );
                     }
                   })}
-                  {API_calendarDataFilter.length > 4 ? (
+                  {ele.API_calendarDataFilter.length > 4 ? (
                     <button>더보기</button>
                   ) : (
                     ""
@@ -124,37 +146,47 @@ export default function Calendar() {
               </div>
             </div>
           ) : (
-            <div key={ele} className={styles.dateBox}>
-              <p className={styles.date} style={cellStyle}>
-                {ele}
-              </p>
-              <div className={styles.dateCultureList}>
-                <ul>
-                  {API_calendarDataFilter.map((data, idx) => {
-                    if (idx < 5) {
-                      return (
-                        <>
-                          <li key={idx} className={styles.calendarDataList}>
-                            <Link href={data.ORG_LINK} target="_blank">
-                              <ExpandedViewText text={data.TITLE} />
-                            </Link>
-                          </li>
-                        </>
-                      );
-                    }
-                  })}
-                  {API_calendarDataFilter.length > 4 ? (
-                    <button onClick={()=>{setIsModalOpen(true)}}>더보기</button>
-                  ) : (
-                    ""
-                  )}
-                </ul>
-              </div>
+            <div
+            key={dateIdx + 1}
+            className={styles.dateBox}
+          > 
+            <p className={styles.date} style={ele.cellStyle}>
+              {ele.date}
+            </p>
+            <div className={styles.dateCultureList}>
+              <ul>
+                {ele.API_calendarDataFilter.map((data, idx) => {
+                  if (idx < 5) {
+                    return (
+                      <React.Fragment key={ele.uniqueIds[idx]}>
+                        <li className={styles.calendarDataList}>
+                          <Link href={data.ORG_LINK} target="_blank">
+                            {data.TITLE}
+                          </Link>
+                          <button>자세히보기</button>
+                        </li>
+                      </React.Fragment>
+                    );
+                  }
+                })}
+                {ele.API_calendarDataFilter.length > 4 ? (
+                  <button>더보기</button>
+                ) : (
+                  ""
+                )}
+              </ul>
             </div>
-          );
+          </div>
+          ) 
         })}
       </div>
-      <Modal isOpen={isModalOpen} onClose={()=>{setIsModalOpen(false)}} text={'text'}/>
+      {/* <Modal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+        }}
+        data={moreData}
+      /> */}
     </div>
   );
 }

--- a/app/cultureCalendar/cultureCalendar.module.css
+++ b/app/cultureCalendar/cultureCalendar.module.css
@@ -65,7 +65,6 @@
   padding: 8px;
   box-sizing: border-box;
   font-weight: 700;
-  margin-bottom: 8px;
 }
 .dates .dateBox .dateCultureList {
   width: 140px;
@@ -90,9 +89,20 @@
 .expandedText{
   background-color: #eee;
   padding: 4px;
-  width: 300px !important;
   box-sizing: border-box;
-  white-space:normal;
+  /* white-space:normal;
   overflow:visible;
-  text-overflow:unset ;
+  text-overflow:unset ; */
+}
+.modalOverlay{
+  border: 1px solid red;
+  z-index: 2;
+  position: fixed;
+  /* top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0; */
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.25);
 }


### PR DESCRIPTION
- 기존 코드는 numbersArray를 기준으로 list를 map돌린 후, numberArr의 각 ele에 해당하는 공연 정보를 filter메서드를 사용해 각 일자에 보여주었다.
- filter한 리스트를 map돌려 li태그에 넣어 보여주었는데,  여기서 key값이 자꾸 겹쳐 버그가 발생하였고 해결 방법을 모색함
- numberArray를 map을 돌려 여기에서 일별 공연 리스트 필터함수와 uniquey한 id생성 및 style 등 list에 들어가는 정보 자체를 하나의 객체로 생성하였다.
- map을 돌린 결과로 date, cellStyle, API_필터 데이터, uniqueId를 return해주었고, 이를 map돌려서 calendar에 보여주었다. 비슷한 코드이지만 전혀 다른 스코프로 동작하므로 겹치는 id가 생성하지 않게 되었다.