### PR TITLE
[ code-refactor ] 배포 후 Mixed Content 에러 해결

### DIFF
--- a/app/components/homeComp/HomeCarousel.jsx
+++ b/app/components/homeComp/HomeCarousel.jsx
@@ -20,12 +20,14 @@ export default function HomeCarousel() {
   const [apiData, setApiData] = useState([]);
   const [isPlaying, setIsPlaying] = useState(true)
 
-  const url = `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/150/`;
-
   // API호출
   useEffect(() => {
-    fetch(url, {
-      method: "GET",
+    fetch(`/api/post/data`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ 'serviceKey': serviceKey, 'type': 'carousel' }),
     })
       .then((res) => res.json())
       .then((result) => {
@@ -56,6 +58,7 @@ export default function HomeCarousel() {
   const handleNextBtn = () => {
     setCurrentSlide(currentSlide === apiData.length - 1 ? 0 : currentSlide + 1);
   };
+
   return (
     <>
       {apiData?.map((i, idx) => {
@@ -71,8 +74,7 @@ export default function HomeCarousel() {
             <button className={styles.autoPlayBtn} onClick={()=>{setIsPlaying((isPlaying)=> !isPlaying)}}>
               {isPlaying? <GiPauseButton/> :<FaPlay /> }
             </button>
-            <img src="/image/ex1.jpg" />
-            {/* <img src={i.MAIN_IMG} alt={i.PROGRAM} width={300} height={400} /> */}
+            <img src={i.MAIN_IMG} alt={i.PROGRAM} width={300} height={400} />
             <div className={styles.mainText}>
               <div>
                 <p>{i.TITLE}</p>

--- a/app/components/homeComp/HomeListItem.jsx
+++ b/app/components/homeComp/HomeListItem.jsx
@@ -6,33 +6,17 @@ import { serviceKey,API_SortFunc, API_FilterFunc } from "@/app/util/utils";
 export default function HomeListItem({ codename }) {
   const [cultureList, setCultureList] = useState([]);
   const curDate = new Date().toISOString().split("T")[0];
-  const url = `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/150/
-  ${codename ? codename : " "}/ /${codename === null ? curDate : " "}`;
-
+  
   useEffect(() => {
-    // fetch(url, {
-    //   method: "GET",
-    // })
-    //   .then((res) => res.json())
-    //   .then((result) => {
-    //     if (result.culturalEventInfo == undefined) {
-    //       setCultureList(null);
-    //       return;
-    //     }
-    //     const lists = result.culturalEventInfo.row;
-    //     const listCopy = [...lists];
-
-    //     const dataSortList = API_SortFunc(listCopy);
-    //     const dataFilterList = API_FilterFunc(dataSortList);
-
-    //     setCultureList(dataFilterList.slice(0, 6));
-    //   });
-    let res = fetch(`/api/post/data`, {
-      method: "GET",
+    fetch(`/api/post/data`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ 'codename': codename, 'curDate': curDate, 'serviceKey': serviceKey , 'type':'homeList'}),
     })
       .then((res) => res.json())
       .then((result) => {
-        // console.log(result)
         if (result.culturalEventInfo == undefined) {
           setCultureList(null);
           return;

--- a/app/cultureCalendar/Calendar.jsx
+++ b/app/cultureCalendar/Calendar.jsx
@@ -24,9 +24,14 @@ export default function Calendar() {
     "0"
   )}`;
   const url = `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/50/ / /${urlDate}`;
+  
   useEffect(() => {
-    fetch(url, {
-      method: "GET",
+    fetch(`/api/post/data`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ 'serviceKey': serviceKey ,'urlDate': urlDate, 'type':'calendar'}),
     })
       .then((res) => res.json())
       .then((result) => {

--- a/app/cultureList/CultureList.jsx
+++ b/app/cultureList/CultureList.jsx
@@ -26,8 +26,12 @@ export default function CultureList() {
   const url = `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/500/${codename}/ /${urlDate}`;
 
   useEffect(() => {
-    fetch(url, {
-      method: "GET",
+    fetch(`/api/post/data`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ 'codename': codename, 'urlDate': urlDate, 'serviceKey': serviceKey , 'type':'cultureList'}),
     })
       .then((res) => res.json())
       .then((result) => {

--- a/app/cultureList/CultureListItem.jsx
+++ b/app/cultureList/CultureListItem.jsx
@@ -9,8 +9,7 @@ export default function CultureListItem({ list }) {
 
   return (
     <div key={uniqueId} className={styles.list}>
-      {/* <img src={list.MAIN_IMG} /> */}
-      <img src="/image/ex1.jpg" />
+      <img src={list.MAIN_IMG} />
       <button className={styles.likeIcon}>
         {/* <FaHeart /> */}
         <FaRegHeart />

--- a/pages/api/post/data.js
+++ b/pages/api/post/data.js
@@ -3,10 +3,21 @@ import { Request, Response } from "express";
 import fetch from "node-fetch";
 
 export default async function handler(req, res) {
-  const API_URL =
-    "http://openapi.seoul.go.kr:8088/6e4957636974686432346a6c614d7a/json/culturalEventInfo/1/10/";
+  // console.log(req.body);
+  const { curDate, codename, serviceKey, type, urlDate } = req.body;
 
-  const response = await fetch(API_URL)
+  const API_URL =
+    type == "homeList"
+      ? `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/150/${
+          codename ? codename : " "
+        }/ /${codename === null ? curDate : " "}`
+      : type == "carousel"
+      ? `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/150/`
+      : type == "cultureList"
+      ? `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/500/${codename}/ /${urlDate}`
+      : `http://openapi.seoul.go.kr:8088/${serviceKey}/json/culturalEventInfo/1/50/ / /${urlDate}`;
+
+  await fetch(API_URL)
     .then((response) => {
       if (!response.ok) {
         throw new Error("API request failed");


### PR DESCRIPTION
- Mixed-content 에러를 발견했을 때의 문제점을 잘못 파악하고 있었음. 
- 클라이언트에서 useEffect와 fetch를 사용해 공공 API 데이터를 사용하였다. 개발모드에서는 문제가 없었지만 vercel로 배포를 하면서 문제가 발생했다.
- 이는 vercel이 HTTPS로 서버를 띄우고, API요청은 HTTP로 데이터를 받아오기 때문에 두 데이터의 충돌로 인해 발생한 에러였다. -- 해결방법으로는 데이터 공공API요청은 서버에서 받아오고, 클라이언트는 서버에서 받아온 데이터로만 화면에 띄워주는 역할을 하는 것으로 문제를 해결했다. 나도 모르게 습관적으로 클라이언트에서 요청을 한 것이다. -> 데이터는 서버로 넘기자.